### PR TITLE
Add Cloudflare deployment docs and scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Flask session secret
+FLASK_SECRET_KEY=change-me-to-a-long-random-secret
+
+# Supabase
+TRELLAR_USE_SUPABASE=1
+SUPABASE_URL=https://your-project-id.supabase.co
+SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
+# Optional demo login override
+TRELLAR_DEMO_EMAIL=demo@trellar.app
+TRELLAR_DEMO_PASSWORD=ChangeMe123!

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ Deretter koble opp siden på cloudflare domenet mitt med en tunnel.
 - Python Flask
 - Ubuntu Server
 
+## Deployment guide
+
+For production hosting on Ubuntu + Cloudflare Tunnel, use:
+
+- `docs/ubuntu-cloudflare-deploy.md`
+- `scripts/install_ubuntu_service.sh`
+- `scripts/install_cloudflare_tunnel.sh`
+
 ## Ubuntu Server Oppsett:
 
 Det jeg startet med å få gjort er å flashe ubuntu server på en gammel laptop.
@@ -206,4 +214,3 @@ sudo systemctl restart systemd-logind
 ```
 
 Dette gjør at maskinen fortsetter å kjøre selv om lokket lukkes.
-

--- a/deploy/cloudflared/config.example.yml
+++ b/deploy/cloudflared/config.example.yml
@@ -1,0 +1,7 @@
+tunnel: TUNNEL_UUID_HERE
+credentials-file: /etc/cloudflared/TUNNEL_UUID_HERE.json
+
+ingress:
+  - hostname: trellar.example.com
+    service: http://localhost:8000
+  - service: http_status:404

--- a/deploy/systemd/trellar.service.example
+++ b/deploy/systemd/trellar.service.example
@@ -1,0 +1,18 @@
+[Unit]
+Description=Trellar Flask app (Gunicorn)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=trellar
+Group=trellar
+WorkingDirectory=/opt/trellar
+EnvironmentFile=-/opt/trellar/.env
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/opt/trellar/.venv/bin/gunicorn --workers 3 --bind 127.0.0.1:8000 --access-logfile - --error-logfile - app:app
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/ubuntu-cloudflare-deploy.md
+++ b/docs/ubuntu-cloudflare-deploy.md
@@ -1,0 +1,123 @@
+# Ubuntu Server + Cloudflare Tunnel Deployment
+
+This guide deploys Trellar on Ubuntu as a `systemd` service and then exposes it through Cloudflare Tunnel when you are ready to attach your domain.
+
+## 1) SSH into your Ubuntu server
+
+From your Mac:
+
+```bash
+ssh <ubuntu-user>@<ubuntu-server-ip>
+```
+
+## 2) Clone and configure the app on Ubuntu
+
+```bash
+git clone <your-repo-url> Trellar
+cd Trellar
+[ -f .env ] || cp .env.example .env
+```
+
+Create or edit `.env` with your production values:
+
+```bash
+nano .env
+```
+
+Minimum recommended values:
+
+```dotenv
+FLASK_SECRET_KEY=replace-with-a-long-random-secret
+TRELLAR_USE_SUPABASE=1
+SUPABASE_URL=...
+SUPABASE_ANON_KEY=...
+SUPABASE_SERVICE_ROLE_KEY=...
+```
+
+## 3) Install and start Trellar as a service
+
+Default is private origin (`127.0.0.1:8000`), best for Cloudflare Tunnel:
+
+```bash
+./scripts/install_ubuntu_service.sh
+```
+
+Check status and logs:
+
+```bash
+sudo systemctl status trellar
+sudo journalctl -u trellar -f
+```
+
+## 4) Optional: allow direct LAN testing before Cloudflare
+
+If you want to open the app on your local network first, bind to all interfaces:
+
+```bash
+BIND_HOST=0.0.0.0 PORT=8000 ./scripts/install_ubuntu_service.sh
+```
+
+If UFW is enabled, allow the port from your LAN:
+
+```bash
+sudo ufw allow from 192.168.0.0/16 to any port 8000 proto tcp
+```
+
+Then test from another device on your Wi-Fi:
+
+```text
+http://<ubuntu-server-ip>:8000
+```
+
+## 5) Later: connect the app to your domain through Cloudflare Tunnel
+
+Install `cloudflared` on Ubuntu (use Cloudflare's official install docs for your Ubuntu version), then run:
+
+```bash
+cloudflared tunnel login
+cloudflared tunnel create trellar
+cloudflared tunnel list
+```
+
+Copy the tunnel UUID and configure hostname + service:
+
+```bash
+./scripts/install_cloudflare_tunnel.sh <tunnel-uuid> <subdomain.yourdomain.com> http://localhost:8000
+```
+
+Example:
+
+```bash
+./scripts/install_cloudflare_tunnel.sh 11111111-2222-3333-4444-555555555555 trellar.example.com http://localhost:8000
+```
+
+This script:
+
+- Writes `/etc/cloudflared/config.yml`
+- Copies tunnel credentials to `/etc/cloudflared/`
+- Creates Cloudflare DNS route for your hostname
+- Installs and starts the `cloudflared` service
+
+Verify:
+
+```bash
+sudo systemctl status cloudflared
+cloudflared tunnel info <tunnel-uuid>
+```
+
+Your app should then be reachable at:
+
+```text
+https://<subdomain.yourdomain.com>
+```
+
+## 6) Updating app code later
+
+On Ubuntu:
+
+```bash
+cd ~/Trellar
+git pull
+./.venv/bin/pip install -r requirements.txt
+sudo systemctl restart trellar
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flask
 supabase
+gunicorn

--- a/scripts/install_cloudflare_tunnel.sh
+++ b/scripts/install_cloudflare_tunnel.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+  echo "Usage: $0 <tunnel-id> <hostname> [origin-url]"
+  echo "Example: $0 11111111-2222-3333-4444-555555555555 trellar.example.com http://localhost:8000"
+  exit 1
+fi
+
+TUNNEL_ID="$1"
+HOSTNAME="$2"
+ORIGIN_URL="${3:-http://localhost:8000}"
+CONFIG_DIR="${CONFIG_DIR:-/etc/cloudflared}"
+CONFIG_PATH="${CONFIG_DIR}/config.yml"
+CREDENTIALS_PATH="${CONFIG_DIR}/${TUNNEL_ID}.json"
+LOCAL_CREDENTIALS_PATH="${HOME}/.cloudflared/${TUNNEL_ID}.json"
+
+if ! command -v cloudflared >/dev/null 2>&1; then
+  echo "cloudflared is not installed." >&2
+  echo "Install cloudflared first, then run this script again." >&2
+  exit 1
+fi
+
+if [[ ! -f "${CREDENTIALS_PATH}" && ! -f "${LOCAL_CREDENTIALS_PATH}" ]]; then
+  echo "Tunnel credentials not found for ${TUNNEL_ID}." >&2
+  echo "Run these first:" >&2
+  echo "  cloudflared tunnel login" >&2
+  echo "  cloudflared tunnel create trellar" >&2
+  exit 1
+fi
+
+echo "[1/4] Preparing ${CONFIG_DIR}..."
+sudo mkdir -p "${CONFIG_DIR}"
+
+if [[ ! -f "${CREDENTIALS_PATH}" ]]; then
+  echo "[2/4] Copying credentials to ${CREDENTIALS_PATH}..."
+  sudo cp "${LOCAL_CREDENTIALS_PATH}" "${CREDENTIALS_PATH}"
+  sudo chmod 600 "${CREDENTIALS_PATH}"
+else
+  echo "[2/4] Credentials already exist at ${CREDENTIALS_PATH}."
+fi
+
+echo "[3/4] Writing ${CONFIG_PATH}..."
+TMP_CONFIG_FILE="$(mktemp)"
+cat >"${TMP_CONFIG_FILE}" <<EOF
+tunnel: ${TUNNEL_ID}
+credentials-file: ${CREDENTIALS_PATH}
+
+ingress:
+  - hostname: ${HOSTNAME}
+    service: ${ORIGIN_URL}
+  - service: http_status:404
+EOF
+
+sudo mv "${TMP_CONFIG_FILE}" "${CONFIG_PATH}"
+sudo chmod 644 "${CONFIG_PATH}"
+
+echo "[4/4] Configuring DNS and starting cloudflared service..."
+cloudflared tunnel route dns "${TUNNEL_ID}" "${HOSTNAME}"
+if systemctl list-unit-files cloudflared.service --no-legend 2>/dev/null | grep -q "^cloudflared\\.service"; then
+  echo "cloudflared service already installed."
+else
+  sudo cloudflared service install
+fi
+sudo systemctl enable --now cloudflared
+sudo systemctl restart cloudflared
+sudo systemctl --no-pager --full status cloudflared || true
+
+echo
+echo "Done."
+echo "Tunnel target: ${ORIGIN_URL}"
+echo "Public hostname: https://${HOSTNAME}"

--- a/scripts/install_ubuntu_service.sh
+++ b/scripts/install_ubuntu_service.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="${APP_NAME:-trellar}"
+APP_DIR="${APP_DIR:-$PWD}"
+APP_USER="${APP_USER:-$USER}"
+APP_GROUP="${APP_GROUP:-$APP_USER}"
+VENV_DIR="${VENV_DIR:-${APP_DIR}/.venv}"
+BIND_HOST="${BIND_HOST:-127.0.0.1}"
+PORT="${PORT:-8000}"
+WORKERS="${WORKERS:-3}"
+UNIT_PATH="/etc/systemd/system/${APP_NAME}.service"
+
+if [[ ! -f "${APP_DIR}/app.py" ]]; then
+  echo "Could not find app.py in APP_DIR=${APP_DIR}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${APP_DIR}/requirements.txt" ]]; then
+  echo "Could not find requirements.txt in APP_DIR=${APP_DIR}" >&2
+  exit 1
+fi
+
+echo "[1/5] Installing Python runtime packages..."
+sudo apt-get update
+sudo apt-get install -y python3 python3-venv python3-pip
+
+echo "[2/5] Creating virtual environment in ${VENV_DIR}..."
+python3 -m venv "${VENV_DIR}"
+"${VENV_DIR}/bin/pip" install --upgrade pip
+"${VENV_DIR}/bin/pip" install -r "${APP_DIR}/requirements.txt"
+
+echo "[3/5] Writing ${UNIT_PATH}..."
+TMP_SERVICE_FILE="$(mktemp)"
+cat >"${TMP_SERVICE_FILE}" <<EOF
+[Unit]
+Description=${APP_NAME} Flask app (Gunicorn)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=${APP_USER}
+Group=${APP_GROUP}
+WorkingDirectory=${APP_DIR}
+EnvironmentFile=-${APP_DIR}/.env
+Environment=PYTHONUNBUFFERED=1
+ExecStart=${VENV_DIR}/bin/gunicorn --workers ${WORKERS} --bind ${BIND_HOST}:${PORT} --access-logfile - --error-logfile - app:app
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo mv "${TMP_SERVICE_FILE}" "${UNIT_PATH}"
+sudo chmod 644 "${UNIT_PATH}"
+
+echo "[4/5] Enabling and starting ${APP_NAME}.service..."
+sudo systemctl daemon-reload
+sudo systemctl enable --now "${APP_NAME}.service"
+
+echo "[5/5] Service status:"
+sudo systemctl --no-pager --full status "${APP_NAME}.service" || true
+
+echo
+echo "Done."
+echo "Check logs with: sudo journalctl -u ${APP_NAME}.service -f"
+echo "Current bind address: http://${BIND_HOST}:${PORT}"


### PR DESCRIPTION
Add deployment tooling and documentation for running Trellar on Ubuntu with Cloudflare Tunnel. Includes: .env.example, docs/ubuntu-cloudflare-deploy.md, example cloudflared and systemd service configs, and two install scripts (install_cloudflare_tunnel.sh, install_ubuntu_service.sh) that automate config, credentials, DNS routing and systemd setup. Also update README to reference the guide and add gunicorn to requirements.txt so the service runs with Gunicorn.